### PR TITLE
Xstream update and Ubuntu support

### DIFF
--- a/src/modules/org.codehaus.xstream/xstream/1.4.8/ivy.xml
+++ b/src/modules/org.codehaus.xstream/xstream/1.4.8/ivy.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2012 Tim Preston
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<ivy-module>
+
+    <info publication="20150218191300">
+        <license name="BSD License" url="http://xstream.codehaus.org/license.html"/>
+        <description homepage="http://xstream.codehaus.org/">
+            XStream is a simple library to serialize objects to XML and back again.
+        </description>
+    </info>
+
+    <configurations>
+        <conf name="xstream" description="XStream Core"/>
+        <conf name="xstream-benchmark" extends="xstream" description="XStream Benchmark Module"/>
+        <conf name="xstream-hibernate" extends="xstream" description="XStream Hibernate Extensions"/>
+	<conf name="time" extends="xstream" description="XStream with advanced time support"/>
+        <conf name="default" extends="xstream" description="XStream Core"/>
+    </configurations>
+
+    <publications>
+        <!-- Jars -->
+        <artifact name="xstream" conf="xstream"/>
+        <artifact name="xstream-benchmark" conf="xstream-benchmark"/>
+        <artifact name="xstream-hibernate" conf="xstream-hibernate"/>
+
+        <!-- Sources -->
+        <artifact name="xstream" type="source" ext="zip" conf="xstream"/>
+        <artifact name="xstream-benchmark" type="source" ext="zip" conf="xstream-benchmark"/>
+        <artifact name="xstream-hibernate" type="source" ext="zip" conf="xstream-hibernate"/>
+
+        <!-- Javadocs -->
+        <artifact name="xstream" type="javadoc" ext="zip" conf="xstream"/>
+        <artifact name="xstream-benchmark" type="javadoc" ext="zip" conf="xstream-benchmark"/>
+        <artifact name="xstream-hibernate" type="javadoc" ext="zip" conf="xstream-hibernate"/>
+    </publications>
+
+    <dependencies>
+        <dependency org="org.xmlpull.xpp3" name="xpp3" rev="1.+" conf="xstream->default"/>
+        <dependency org="org.hibernate" name="hibernate" rev="4.1.4.Final" conf="xstream-hibernate->core"/>
+	<dependency org="org.joda" name="joda-time" rev="1.6+" conf="time->default"/>
+    </dependencies>
+
+</ivy-module>

--- a/src/modules/org.codehaus.xstream/xstream/1.4.8/packager.xml
+++ b/src/modules/org.codehaus.xstream/xstream/1.4.8/packager.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2012 Tim Preston
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<packager-module rev="$Id$">
+    <m2resource groupId="com/thoughtworks/xstream">
+        <artifact tofile="artifacts/jars/xstream.jar" sha1="520d90f30f36a0d6ba2dc929d980831631ad6a92"/>
+        <artifact classifier="sources" tofile="artifacts/sources/xstream.zip" sha1="f94a2c20633765ae495647bfeee63560bd20f700"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/xstream.zip" sha1="8ddce9c5b33eaf0f28758d36f8962e5bacbf4d80"/>
+    </m2resource>
+    <m2resource groupId="com/thoughtworks/xstream" artifactId="xstream-benchmark">
+        <artifact tofile="artifacts/jars/xstream-benchmark.jar" sha1="6f6f14a0ef190990924052a3298d70effadc6541"/>
+        <artifact classifier="sources" tofile="artifacts/sources/xstream-benchmark.zip" sha1="30355e05ca1c167272f3e5da656fa4399dcf3696"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/xstream-benchmark.zip" sha1="d301c99d2e47ab47e8b60db6b11d870893ec0081"/>
+    </m2resource>
+    <m2resource groupId="com/thoughtworks/xstream" artifactId="xstream-hibernate">
+        <artifact tofile="artifacts/jars/xstream-hibernate.jar" sha1="180162ef6be164fc06defa321d87823f5df8631a"/>
+        <artifact classifier="sources" tofile="artifacts/sources/xstream-hibernate.zip" sha1="531d74a643d4e365187ef8dc04c39a40959de37d"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/xstream-hibernate.zip" sha1="834ac3594209b1972e872b1a5f1abc9b8d92648e"/>
+    </m2resource>
+</packager-module>

--- a/src/scripts/update-maven-checksums.sh
+++ b/src/scripts/update-maven-checksums.sh
@@ -22,7 +22,7 @@ case `uname -s` in
 esac
 
 # Find saxon
-for NAME in saxon{9,8,}; do
+for NAME in saxon{9,8,b-xslt,}; do
     SAXON=`which "${NAME}" 2>/dev/null || true`
     if [ -n "${SAXON}" ]; then
         break


### PR DESCRIPTION
The first commit adds Ubuntu support for the maven update tool.  The second commit adds the latest version of Xstream and adds a missing optional dependency.  It's a little awkward that I can't seem to find a way to make Github make these two separate pull requests.