### PR TITLE
Added w3c flute 1.3, Xerces 2.9.0

### DIFF
--- a/src/modules/org.apache.xerces/xerces/2.9.0/ivy.xml
+++ b/src/modules/org.apache.xerces/xerces/2.9.0/ivy.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2008 Archie L. Cobbs
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<ivy-module>
+
+    <info publication="20061123120000">
+        <license name="Apache License, Version 2.0" url="http://www.apache.org/licenses/LICENSE-2.0"/>
+        <description homepage="http://xerces.apache.org/">
+            Apache Xerces is a collaborative software development
+            project dedicated to providing robust, full-featured,
+            commercial-quality, and freely available XML parsers
+            and closely related technologies on a wide variety of
+            platforms supporting several languages. This project is
+            managed in cooperation with various individuals worldwide
+            (both independent and company-affiliated experts), who use
+            the Internet to communicate, plan, and develop XML software
+            and related documentation.
+        </description>
+    </info>
+
+    <configurations>
+        <conf name="apis" description="XML APIs only"/>
+        <conf name="impl" description="Xerces implementation only"/>
+        <conf name="serializer" description="Xerces serializer only"/>
+        <conf name="default" extends="impl,apis,serializer" description="Xerces implementation, serializer, and XML APIs"/>
+    </configurations>
+
+    <publications>
+        <artifact name="xercesImpl" conf="impl"/>
+        <artifact name="serializer" conf="serializer"/>
+        <artifact name="source" type="source" ext="zip"/>
+        <artifact name="javadoc" type="javadoc" ext="zip"/>
+        <artifact name="javadoc-other" type="javadoc" ext="zip"/>
+        <artifact name="javadoc-xerces2" type="javadoc" ext="zip"/>
+        <artifact name="javadoc-xni" type="javadoc" ext="zip"/>
+        <artifact name="javadoc-xs" type="javadoc" ext="zip"/>
+    </publications>
+
+    <dependencies>
+        <dependency org="org.apache.xml" name="xml-commons-external" rev="1.3+" conf="apis->default"/>
+    </dependencies>
+
+</ivy-module>

--- a/src/modules/org.apache.xerces/xerces/2.9.0/packager.xml
+++ b/src/modules/org.apache.xerces/xerces/2.9.0/packager.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2008 Archie L. Cobbs
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<packager-module>
+
+    <property name="name" value="xerces"/>
+    <property name="Name" value="Xerces"/>
+    <property name="revision" value="2.9.0"/>
+    <property name="_version" value="2_9_0"/>
+
+    <property name="binarchive" value="${Name}-J-bin.${revision}"/>
+    <property name="srcarchive" value="${Name}-J-src.${revision}"/>
+    <property name="archdir" value="${name}-${_version}"/>
+
+    <resource dest="binarchive" url="http://archive.apache.org/dist/xml/${name}-j/${binarchive}.tar.gz"
+      sha1="993a612fe2515ea4223084058c6f195b8b139dc0">
+        <include name="${archdir}/${name}Impl.jar"/>
+        <include name="${archdir}/docs/javadocs/**/*"/>
+        <include name="${archdir}/serializer.jar"/>
+    </resource>
+    <resource dest="srcarchive" url="http://archive.apache.org/dist/xml/${name}-j/${srcarchive}.tar.gz"
+      sha1="0dddc1a59dfb75cc2264258df25cf6c23ae57f97">
+        <include name="${archdir}/src/**/*"/>
+    </resource>
+
+    <build>
+        <!-- jars -->
+        <move file="binarchive/${archdir}/${name}Impl.jar" todir="artifacts/jars"/>
+        <move file="binarchive/${archdir}/serializer.jar" todir="artifacts/jars"/>
+
+        <!-- source -->
+        <zip destfile="artifacts/sources/source.zip">
+            <fileset dir="srcarchive/${archdir}/src"/>
+        </zip>
+
+        <!-- javadocs -->
+        <zip destfile="artifacts/javadocs/javadoc.zip">
+            <fileset dir="binarchive/${archdir}/docs/javadocs/api"/>
+        </zip>
+        <zip destfile="artifacts/javadocs/javadoc-other.zip">
+            <fileset dir="binarchive/${archdir}/docs/javadocs/other"/>
+        </zip>
+        <zip destfile="artifacts/javadocs/javadoc-${name}2.zip">
+            <fileset dir="binarchive/${archdir}/docs/javadocs/${name}2"/>
+        </zip>
+        <zip destfile="artifacts/javadocs/javadoc-xni.zip">
+            <fileset dir="binarchive/${archdir}/docs/javadocs/xni"/>
+        </zip>
+        <zip destfile="artifacts/javadocs/javadoc-xs.zip">
+            <fileset dir="binarchive/${archdir}/docs/javadocs/xs"/>
+        </zip>
+    </build>
+</packager-module>

--- a/src/modules/org.w3c.css/flute/1.3/ivy.xml
+++ b/src/modules/org.w3c.css/flute/1.3/ivy.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2009 Joshua Tharp
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<ivy-module>
+    <info publication="20020617000000">
+        <license
+            name="W3C IPR SOFTWARE NOTICE"
+            url="http://www.w3.org/Consortium/Legal/copyright-software-19980720"/>
+        <description homepage="http://www.w3.org/Style/CSS/SAC/">
+Flute is the reference implementation of SAC.
+        </description>
+    </info>
+
+    <configurations>
+      <conf
+          name="nodeps"
+          description="Only the module jars, no dependencies" />
+      <conf
+          name="default"
+          extends="nodeps"
+          description="Core and dependencies" />
+      <conf
+          name="javadoc"
+          description="API documentation" />
+      <conf
+          name="source"
+          description="Source code" />
+    </configurations>
+
+    <publications>
+      <!-- Core artifacts -->
+      <artifact
+          type="jar"
+          conf="nodeps" />
+
+      <!-- Javadoc artifacts -->
+      <artifact
+          name="flute-javadoc"
+          type="javadoc"
+          ext="zip"
+          conf="javadoc" />
+
+      <!-- Source artifacts -->
+      <artifact
+          name="flute-source"
+          type="source"
+          ext="zip"
+          conf="source" />
+    </publications>
+
+    <dependencies>
+        <dependency org="org.w3c.css" name="sac" rev="1.3" conf="default->default"/>
+    </dependencies>
+</ivy-module>

--- a/src/modules/org.w3c.css/flute/1.3/packager.xml
+++ b/src/modules/org.w3c.css/flute/1.3/packager.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2009 Joshua Tharp
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<packager-module
+>
+  <property name="name" value="${ivy.packager.module}"/>
+  <property name="revision" value="${ivy.packager.revision}"/>
+  <property name="archive" value="${name}-${revision}"/>
+
+  <resource
+      url="http://www.w3.org/2002/06/flutejava-1.3.zip"
+      sha1="6053017a777a66d23fa1755ff5c5495d123fa667">
+    <include name="${archive}/doc/**" />
+    <include name="${archive}/${name}.jar" />
+    <include name="${archive}/org/**" />
+  </resource>
+
+  <build>
+    <!-- jar -->
+    <move
+        file="archive/${archive}/${name}.jar"
+        tofile="artifacts/jars/${name}.jar"/>
+
+    <!-- source -->
+    <zip destfile="artifacts/sources/${name}-source.zip">
+      <fileset dir="archive/${archive}">
+        <include name="org/**" />
+      </fileset>
+    </zip>
+
+    <!-- javadoc -->
+    <zip destfile="artifacts/javadocs/${name}-javadoc.zip">
+      <fileset dir="archive/${archive}/doc" />
+    </zip>
+  </build>
+</packager-module>
+


### PR DESCRIPTION
Added w3c flute 1.3, often referred to (incorrectly?) as Mylin flute, modeled after w3c sac.
Added Xerces 2.9.0, modeled after 2.9.1.