### PR TITLE
Various additions of versions.

### DIFF
--- a/src/modules/com.ibm.icu/icu4j/50.1.1/ivy.xml
+++ b/src/modules/com.ibm.icu/icu4j/50.1.1/ivy.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2012 Martin Weber
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<ivy-module>
+
+  <info publication="20121217162600">
+    <license name="ICU License"
+      url="http://source.icu-project.org/repos/icu/icu/trunk/license.html" />
+    <description homepage="http://site.icu-project.org/">
+      <p>ICU is a mature, widely used set of C/C++ and Java libraries
+        providing Unicode and Globalization support for software
+        applications. ICU is widely portable and gives applications the
+        same results on all platforms and between C/C++ and Java
+        software.
+     </p>
+      <p>NOTE: The new ICU release version numbering combines the
+        former first two fields into a single field.
+     </p>
+    </description>
+  </info>
+
+  <configurations>
+    <conf name="default" description="Core classes" />
+    <conf name="charsets" extends="default"
+      description="Extra character set conversion classes" />
+    <conf name="localespi" extends="default"
+      description="Locale SPI implementation classes" />
+  </configurations>
+
+  <publications>
+    <artifact conf="default" />
+    <artifact conf="charsets" name="icu4j-charset" />
+    <artifact conf="localespi" name="icu4j-localespi" />
+    <artifact conf="default" name="source" type="source" ext="zip" />
+    <artifact conf="default" name="javadoc" type="javadoc" ext="zip" />
+    <artifact conf="charsets" name="charset-source" type="source"
+      ext="zip" />
+    <artifact conf="localespi" name="localespi-source" type="source"
+      ext="zip" />
+  </publications>
+
+</ivy-module>

--- a/src/modules/com.ibm.icu/icu4j/50.1.1/packager.xml
+++ b/src/modules/com.ibm.icu/icu4j/50.1.1/packager.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2012 Martin Weber
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<packager-module
+ >
+
+  <property name="name" value="${ivy.packager.module}" />
+  <property name="revision" value="${ivy.packager.revision}" />
+  <property name="archive" value="${name}-${revision}" />
+  <property name="url"
+    value="http://download.icu-project.org/files/icu4j/50.1.1/" />
+
+  <!-- jar -->
+  <resource url="${url}/icu4j-50_1_1.jar" tofile="artifacts/jars/${name}.jar"
+    sha1="c1267563fd08f2885bc1f934ddaca15d19c3d888" />
+  <resource url="${url}/icu4j-charset-50_1_1.jar" tofile="artifacts/jars/${name}-charset.jar"
+    sha1="56a1cf1f7263525e1897f7de2f9d4891adb701ab" />
+  <resource url="${url}/icu4j-localespi-50_1_1.jar" tofile="artifacts/jars/${name}-localespi.jar"
+    sha1="ea529d5e6f709dc5f96acef13e1d53ce1941f800" />
+  <!-- source -->
+  <resource url="${url}/icu4j-50_1_1-src.jar" tofile="artifacts/sources/source.zip"
+    sha1="145e5c32cb7a6bcf8120a134c48206d870c12394" />
+  <resource url="${url}/icu4j-charset-50_1_1-src.jar" tofile="artifacts/sources/charset-source.zip"
+    sha1="eff6ce9317537dc60b03be580db8794436c3319a" />
+  <resource url="${url}/icu4j-localespi-50_1_1-src.jar" tofile="artifacts/sources/localespi-source.zip"
+    sha1="972f6a692f61be4f3d2f51ca498bd703f80aa9eb" />
+  <!-- javadoc -->
+  <resource url="${url}/icu4j-50_1_1-docs.jar" tofile="artifacts/javadocs/javadoc.zip"
+    sha1="656f522a1876fa2cf3d48c2c1330d8d49fb1c0d7" />
+
+</packager-module>

--- a/src/modules/org.apache.commons/commons-cli/1.0/ivy.xml
+++ b/src/modules/org.apache.commons/commons-cli/1.0/ivy.xml
@@ -18,7 +18,7 @@
 
 <ivy-module>
 
-    <info publication="20070708000000">
+    <info publication="20021106000000"> <!-- FIX, might be wrong for 1.1 too -->
         <license name="Apache License, Version 2.0" url="http://www.apache.org/licenses/LICENSE-2.0"/>
         <description homepage="http://commons.apache.org/proper/commons-cli/">
             The Apache Commons CLI library provides an API for processing command line interfaces.

--- a/src/modules/org.apache.commons/commons-cli/1.0/packager.xml
+++ b/src/modules/org.apache.commons/commons-cli/1.0/packager.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="ISO-8859-1"?>
 
 <!--
     Copyright 2008 Archie L. Cobbs.
@@ -16,19 +16,10 @@
     under the License.
 -->
 
-<ivy-module>
-
-    <info publication="20070708000000">
-        <license name="Apache License, Version 2.0" url="http://www.apache.org/licenses/LICENSE-2.0"/>
-        <description homepage="http://commons.apache.org/proper/commons-cli/">
-            The Apache Commons CLI library provides an API for processing command line interfaces.
-        </description>
-    </info>
-
-    <publications>
-        <artifact/>
-        <artifact name="source" type="source" ext="zip"/>
-        <artifact name="javadoc" type="javadoc" ext="zip"/>
-    </publications>
-
-</ivy-module>
+<packager-module>
+    <m2resource groupId="${ivy.packager.module}">
+        <artifact tofile="artifacts/jars/${ivy.packager.module}.jar" sha1="6dac9733315224fc562f6268df58e92d65fd0137"/>
+        <artifact classifier="sources" tofile="artifacts/sources/source.zip" sha1="fc9b2f6fb941aadf5ea34f68c983b0e6bfbf2ca7"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/javadoc.zip" sha1="9bbcb06df5f4259391d582013f007c683494fb1d"/>
+    </m2resource>
+</packager-module>

--- a/src/modules/org.apache.commons/commons-cli/1.3.1/ivy.xml
+++ b/src/modules/org.apache.commons/commons-cli/1.3.1/ivy.xml
@@ -18,7 +18,7 @@
 
 <ivy-module>
 
-    <info publication="20150614000000">
+    <info publication="20150617000000">
         <license name="Apache License, Version 2.0" url="http://www.apache.org/licenses/LICENSE-2.0"/>
         <description homepage="http://commons.apache.org/proper/commons-cli/">
             The Apache Commons CLI library provides an API for processing command line interfaces.

--- a/src/modules/org.apache.commons/commons-lang/1.0/ivy.xml
+++ b/src/modules/org.apache.commons/commons-lang/1.0/ivy.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2008 Archie L. Cobbs.
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<ivy-module>
+
+    <info publication="20051122180900">
+        <license name="Apache License, Version 2.0" url="http://www.apache.org/licenses/LICENSE-2.0"/>
+        <description homepage="http://commons.apache.org/proper/commons-lang/">
+            <p>
+            The standard Java libraries fail to provide enough methods
+            for manipulation of its core classes. The Lang Component
+            provides these extra methods.
+            </p>
+
+            <p>
+            The Lang Component provides a host of helper utilities for
+            the java.lang API, notably String manipulation methods,
+            basic numerical methods, object reflection, creation and
+            serialization, and System properties. Additionally it contains
+            an inheritable enum type, an exception structure that supports
+            multiple types of nested-Exceptions, basic enhancements to
+            java.util.Date and a series of utilities dedicated to help
+            with building methods, such as hashCode, toString and equals.
+            </p>
+        </description>
+    </info>
+
+    <publications>
+        <artifact/>
+        <artifact name="javadoc" type="javadoc" ext="zip"/>
+    </publications>
+
+</ivy-module>

--- a/src/modules/org.apache.commons/commons-lang/1.0/packager.xml
+++ b/src/modules/org.apache.commons/commons-lang/1.0/packager.xml
@@ -16,19 +16,10 @@
     under the License.
 -->
 
-<ivy-module>
+<packager-module>
+    <m2resource groupId="${ivy.packager.module}">
+        <artifact tofile="artifacts/jars/${ivy.packager.module}.jar" sha1="ac4ab3b02823ea2997c163433d9d44132bd2446a"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/javadoc.zip" sha1="01af3a2ac1a4c2d874bf69937d2b9da78ccad03f"/>
+    </m2resource>
+</packager-module>
 
-    <info publication="20070708000000">
-        <license name="Apache License, Version 2.0" url="http://www.apache.org/licenses/LICENSE-2.0"/>
-        <description homepage="http://commons.apache.org/proper/commons-cli/">
-            The Apache Commons CLI library provides an API for processing command line interfaces.
-        </description>
-    </info>
-
-    <publications>
-        <artifact/>
-        <artifact name="source" type="source" ext="zip"/>
-        <artifact name="javadoc" type="javadoc" ext="zip"/>
-    </publications>
-
-</ivy-module>

--- a/src/modules/org.apache.xml/xml-commons-external/1.0.b2/ivy.xml
+++ b/src/modules/org.apache.xml/xml-commons-external/1.0.b2/ivy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-    Copyright 2008 Archie L. Cobbs.
+    Copyright 2009 Mark Thomas
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may
     not use this file except in compliance with the License. You may obtain
@@ -18,17 +18,23 @@
 
 <ivy-module>
 
-    <info publication="20070708000000">
+    <info publication="20030913003800">
         <license name="Apache License, Version 2.0" url="http://www.apache.org/licenses/LICENSE-2.0"/>
-        <description homepage="http://commons.apache.org/proper/commons-cli/">
-            The Apache Commons CLI library provides an API for processing command line interfaces.
-        </description>
+        <description homepage="http://xerces.apache.org/xml-commons/"><![CDATA[
+        The External Components portion of xml-commons contains interfaces that
+        are defined by external standards organizations. For DOM, that's the
+        W3C; for SAX it's David Megginson and sax.sourceforge.net; for JAXP
+        it's Sun.
+        ]]></description>
     </info>
 
+    <configurations>
+        <conf name="default" description="Main plus extension interfaces, e.g. SVG"/>
+    </configurations>
+
     <publications>
-        <artifact/>
+        <artifact name="xml-apis" conf="default"/>
         <artifact name="source" type="source" ext="zip"/>
-        <artifact name="javadoc" type="javadoc" ext="zip"/>
     </publications>
 
 </ivy-module>

--- a/src/modules/org.apache.xml/xml-commons-external/1.0.b2/packager.xml
+++ b/src/modules/org.apache.xml/xml-commons-external/1.0.b2/packager.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-    Copyright 2008 Archie L. Cobbs.
+    Copyright 2009 Mark Thomas
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may
     not use this file except in compliance with the License. You may obtain
@@ -16,19 +16,9 @@
     under the License.
 -->
 
-<ivy-module>
-
-    <info publication="20070708000000">
-        <license name="Apache License, Version 2.0" url="http://www.apache.org/licenses/LICENSE-2.0"/>
-        <description homepage="http://commons.apache.org/proper/commons-cli/">
-            The Apache Commons CLI library provides an API for processing command line interfaces.
-        </description>
-    </info>
-
-    <publications>
-        <artifact/>
-        <artifact name="source" type="source" ext="zip"/>
-        <artifact name="javadoc" type="javadoc" ext="zip"/>
-    </publications>
-
-</ivy-module>
+<packager-module>
+    <m2resource groupId="xml-apis" artifactId="xml-apis">
+        <artifact tofile="artifacts/jars/xml-apis.jar" sha1="3136ca936f64c9d68529f048c2618bd356bf85c9"/>
+        <artifact classifier="sources" tofile="artifacts/sources/source.zip" sha1="d8525661c5a0a05702fa41873d250d135031ec25"/>
+    </m2resource>
+</packager-module>

--- a/src/modules/org.junit/junit/3.7/ivy.xml
+++ b/src/modules/org.junit/junit/3.7/ivy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-    Copyright 2008 Archie L. Cobbs.
+    Copyright 2008 Archie L. Cobbs
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may
     not use this file except in compliance with the License. You may obtain
@@ -18,17 +18,19 @@
 
 <ivy-module>
 
-    <info publication="20070708000000">
-        <license name="Apache License, Version 2.0" url="http://www.apache.org/licenses/LICENSE-2.0"/>
-        <description homepage="http://commons.apache.org/proper/commons-cli/">
-            The Apache Commons CLI library provides an API for processing command line interfaces.
-        </description>
+    <info publication="20010521000000">
+        <license name="Common Public License, Version 1.0" url="https://opensource.org/licenses/cpl1.0"/>
+        <description homepage="http://junit.sourceforge.net/">A Java unit testing framework.</description>
     </info>
+
+    <configurations>
+        <conf name="default" description="Default configuration"/>
+    </configurations>
 
     <publications>
         <artifact/>
-        <artifact name="source" type="source" ext="zip"/>
-        <artifact name="javadoc" type="javadoc" ext="zip"/>
+        <artifact type="source" ext="zip"/>
+        <artifact type="javadoc" ext="zip"/>
     </publications>
 
 </ivy-module>

--- a/src/modules/org.junit/junit/3.7/packager.xml
+++ b/src/modules/org.junit/junit/3.7/packager.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2008 Archie L. Cobbs
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<packager-module>
+
+    <property name="name" value="${ivy.packager.module}"/>
+    <property name="revision" value="${ivy.packager.revision}"/>
+    <property name="archive" value="${name}${revision}"/>
+
+    <resource url="http://downloads.sourceforge.net/project/${name}/${name}/${revision}/${archive}.zip"
+      sha1="42beaabbb4a321288f90e36adf0dcc05a255dda4">
+        <include name="${archive}/${name}.jar"/>
+        <include name="${archive}/src.jar"/>
+        <include name="${archive}/javadoc/**/*"/>
+    </resource>
+
+    <build>
+        <!-- jar -->
+        <move file="archive/${archive}/${name}.jar" tofile="artifacts/jars/${name}.jar"/>
+
+        <!-- source -->
+        <move file="archive/${archive}/src.jar" tofile="artifacts/sources/${name}.zip"/>
+
+        <!-- javadoc -->
+        <zip destfile="artifacts/javadocs/${name}.zip">
+            <fileset dir="archive/${archive}/javadoc"/>
+        </zip>
+    </build>
+</packager-module>


### PR DESCRIPTION
Added junit 3.7 based on other versions.
Added commons-lang 1.0 based on other versions.
Added xml-commons-external 1.0.b2. The binaries are not available in the Apache archive like other versions, and must be gotten from Maven. Therefore it is in a different format from the newer versions.
Added icu4j 50.1.1 based on 49.1.
Added commons-cli 1.0 based on 1.1.
Adjusted commons-cli release dates based on the following information: https://commons.apache.org/proper/commons-cli/changes-report.html