### PR TITLE
Add Google GWT 2.6.1

### DIFF
--- a/src/modules/com.google/gwt/2.6.1/ivy.xml
+++ b/src/modules/com.google/gwt/2.6.1/ivy.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2013 Stephen Lynn
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<ivy-module>
+
+    <info publication="20140509120000">
+        <license name="Apache License, Version 2.0" url="http://www.apache.org/licenses/LICENSE-2.0"/>
+        <description homepage="http://www.gwtproject.org/">
+
+            <p>
+            Google Web Toolkit (GWT) is a development toolkit for building
+            and optimizing complex browser-based applications. Its goal
+            is to enable productive development of high-performance web
+            applications without the developer having to be an expert in
+            browser quirks, XMLHttpRequest, and JavaScript. GWT is used
+            by many products at Google, including Google Wave and the
+            new version of AdWords. It's open source, completely free,
+            and used by thousands of developers around the world.
+            </p>
+
+            <h2>Developing with Google Web Toolkit</h2>
+
+            <h3>Write</h3>
+
+            <p>
+            The GWT SDK provides a set of core Java APIs and Widgets. These allow
+            you to write AJAX applications in Java and then compile the source to
+            highly optimized JavaScript that runs across all browsers, including
+            mobile browsers for Android and the iPhone.
+            </p>
+
+            <p>
+            Constructing AJAX applications in this manner is more productive thanks
+            to a higher level of abstraction on top of common concepts like DOM
+            manipulation and XHR communication.
+            </p>
+
+            <p>
+            You aren't limited to pre-canned widgets either. Anything you can do
+            with the browser's DOM and JavaScript can be done in GWT, including
+            interacting with hand-written JavaScript.
+            </p>
+
+            <h3>Debug</h3>
+
+            <p>
+            You can debug AJAX applications in your favorite IDE just like you would
+            a desktop application, and in your favorite browser just like you would
+            if you were coding JavaScript. The GWT developer plugin spans the gap
+            between Java bytecode in the debugger and the browser's JavaScript.
+            </p>
+
+            <p>
+            Thanks to the GWT developer plugin, there's no compiling of code
+            to JavaScript to view it in the browser. You can use the same
+            edit-refresh-view cycle you're used to with JavaScript, while at the
+            same time inspect variables, set breakpoints, and utilize all the other
+            debugger tools available to you with Java. And because GWT's development
+            mode is now in the browser itself, you can use tools like Firebug and
+            Inspector as you code in Java.
+            </p>
+
+            <h3>Optimize</h3>
+
+            <p>
+            Google Web Toolkit contains two powerful tools for creating optimized
+            web applications. The GWT compiler performs comprehensive optimizations
+            across your codebase ? in-lining methods, removing dead code, optimizing
+            strings, and more. By setting split-points in the code, it can also
+            segment your download into multiple JavaScript fragments, splitting up
+            large applications for faster startup time.
+            </p>
+
+            <p>
+            Performance bottlenecks aren't limited to JavaScript. Browser layout
+            and CSS often behave in strange ways that are hard to diagnose. Speed
+            Tracer is a new Chrome Extension in Google Web Toolkit that enables you
+            to diagnose performance problems in the browser.
+            </p>
+
+            <h3>Run</h3>
+
+            <p>
+            When you're ready to deploy, GWT compiles your Java source code into
+            optimized, stand-alone JavaScript files that automatically run on all
+            major browsers, as well as mobile browsers for Android and the iPhone.
+            </p>
+
+        </description>
+    </info>
+
+    <configurations>
+        <conf name="compile" description="GWT compiler"/>
+        <conf name="runtime" description="Server-side runtime support for GWT RPC"/>
+        <conf name="api-checker" description="API Checker support"/>
+        <conf name="module-dtd" description="GWT module XML file DTD"/>
+        <conf name="windows-swt" description="Windows DLL support for development mode"/>
+        <conf name="default" extends="compile,runtime" description="Development and runtime JARs"/>
+    </configurations>
+
+    <publications>
+        <artifact name="gwt-user" conf="compile"/>
+        <artifact name="gwt-dev" conf="compile"/>
+        <artifact name="gwt-soyc-vis" conf="compile"/>
+        <artifact name="gwt-api-checker" conf="api-checker"/>
+        <artifact name="gwt-servlet" xmlns:ivyde="http://ant.apache.org/ivy/ivyde/ns/" ivyde:source="gwt-user" conf="runtime"/>
+        <artifact name="gwt-module" type="dtd" conf="module-dtd"/>
+        <artifact name="gwt-ll" type="dll" conf="windows-swt"/>
+        <artifact name="javadoc" type="javadoc" ext="zip"/>
+    </publications>
+
+    <dependencies>
+        <dependency org="javax.validation" name="validation-api" rev="1.0.0.GA" conf="compile-&gt;default"/>
+    </dependencies>
+</ivy-module>

--- a/src/modules/com.google/gwt/2.6.1/packager.xml
+++ b/src/modules/com.google/gwt/2.6.1/packager.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2013 Stephen Lynn
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<packager-module>
+
+    <property name="name" value="${ivy.packager.module}"/>
+    <property name="revision" value="${ivy.packager.revision}"/>
+    <property name="archive" value="${name}-${revision}"/>
+
+    <resource url="http://storage.googleapis.com/gwt-releases/${archive}.zip"
+      sha1="8ebc808e9ca6ef7e8f6460c8c0840423c192b3c5">
+        <include name="${archive}/*.jar"/>
+        <include name="${archive}/*.dll"/>
+        <include name="${archive}/*.dtd"/>
+        <include name="${archive}/doc/javadoc/**/*"/>
+    </resource>
+
+    <build>
+        <!-- jars -->
+        <move todir="artifacts/jars">
+            <fileset dir="archive/${archive}" includes="*.jar"/>
+        </move>
+
+        <!-- windows DLLs -->
+        <mkdir dir="artifacts/dlls"/>
+        <move todir="artifacts/dlls">
+            <fileset dir="archive/${archive}" includes="*.dll"/>
+        </move>
+
+        <!-- DTDs -->
+        <mkdir dir="artifacts/dtds"/>
+        <move todir="artifacts/dtds">
+            <fileset dir="archive/${archive}" includes="*.dtd"/>
+        </move>
+
+        <!-- javadoc -->
+        <zip destfile="artifacts/javadocs/javadoc.zip">
+            <fileset dir="archive/${archive}/doc/javadoc"/>
+        </zip>
+    </build>
+</packager-module>


### PR DESCRIPTION
Based entirely on rev 2.5.1.  Updated only publication date and resource URL/SHA1.  Sources only.

Was unable to get the ant build to generate the new rev repo entries.

`ant -Dresolve.mod=gwt get-xalan clean repo resolve` completes with as a success, but wipes out all entries in modules.xml, `repo/modules/**/ivy.xml` and `repo/modules/**/packager.xml`.  I suspect it may somehow have to do with the using the `get-xalan` task.  I'm running Mac OS X 10.11.6 with Ant 1.9.6 for reference (and Ivy 2.3.0 if that matters).  

I did test locally by making copies of the repo entries for 2.5.1, updating the relevant fields and running a build referencing the new dependency.  Confirmed GWT 2.6.1 was downloaded and cached in my local ~/.ivy.  