### PR TITLE
Added OWASP's Java HTML Sanitizer.

### DIFF
--- a/src/modules/org.owasp/java-html-sanitizer/20180219.1/ivy.xml
+++ b/src/modules/org.owasp/java-html-sanitizer/20180219.1/ivy.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2018 Bill Soul
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<ivy-module>
+
+    <info publication="20180219103806">
+        <license name="Apache License, Version 2.0" url="http://www.apache.org/licenses/LICENSE-2.0"/>
+        <license name="New BSD License" url="https://opensource.org/licenses/BSD-3-Clause"/>
+        <description homepage="https://www.owasp.org/index.php/OWASP_Java_HTML_Sanitizer_Project">
+            The OWASP HTML Sanitizer is a fast and easy to configure HTML Sanitizer written in Java which lets you include HTML authored by third-parties in your web application while protecting against XSS.
+        </description>
+    </info>
+
+    <configurations>
+        <conf name="core" description="Core classes"/>
+        <conf name="default" extends="core" description="Alias for core"/>
+    </configurations>
+
+    <publications>
+        <artifact name="owasp-java-html-sanitizer" type="jar" ext="jar" conf="core"/>
+        <artifact name="source" type="source" ext="zip"/>
+        <artifact name="javadoc" type="javadoc" ext="zip"/>
+    </publications>
+
+    <dependencies>
+        <dependency org="com.google.guava" name="guava" rev="[11,)" conf="core->default"/>
+    </dependencies>
+
+</ivy-module>

--- a/src/modules/org.owasp/java-html-sanitizer/20180219.1/packager.xml
+++ b/src/modules/org.owasp/java-html-sanitizer/20180219.1/packager.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2018 Bill Soul
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<packager-module>
+    <m2resource groupId="com.googlecode.owasp-java-html-sanitizer" artifactId="owasp-java-html-sanitizer">
+        <artifact tofile="artifacts/jars/owasp-java-html-sanitizer.jar" sha1="d712a56cb2fecdb2d6d8d30db409284fdb87e339"/>
+        <artifact classifier="sources" tofile="artifacts/sources/source.zip" sha1="701f6195d87991aa9c66025f65bf74dd7bb041cc"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/javadoc.zip" sha1="fff99cf5c5ced781b75654194c90ec92df1c6e32"/>
+    </m2resource>
+</packager-module>


### PR DESCRIPTION
I did this using org.owasp, rather than creating another org.owasp.XXX organization, especially in this case because the naming is just getting nasty as compared to Maven. Is following an established convention here preferable even if it is wrong? Ideally, this and all other owasp items should be moved (or copied?) inside org.owasp, but I did not touch the others.