### PR TITLE
New commons-lang3 version, new commons-text library

### DIFF
--- a/src/modules/org.apache.commons/commons-lang3/3.9/ivy.xml
+++ b/src/modules/org.apache.commons/commons-lang3/3.9/ivy.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2014 Zac Jacobson.
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<ivy-module>
+
+    <info publication="20190411000000">
+        <license name="Apache License, Version 2.0" url="http://www.apache.org/licenses/LICENSE-2.0"/>
+        <description homepage="http://commons.apache.org/proper/commons-lang/">
+            <p>
+            The standard Java libraries fail to provide enough methods
+            for manipulation of its core classes. Apache Commons Lang
+            provides these extra methods.
+            </p>
+
+            <p>
+            Lang provides a host of helper utilities for
+            the java.lang API, notably String manipulation methods,
+            basic numerical methods, object reflection, concurrency, creation and
+            serialization and System properties. Additionally it contains
+            basic enhancements to
+            java.util.Date and a series of utilities dedicated to help
+            with building methods, such as hashCode, toString and equals.
+            </p>
+
+            <p>
+            Note that Lang 3.0 (and subsequent versions) use a different package
+            (org.apache.commons.lang3) than the previous versions
+            (org.apache.commons.lang), allowing it to be used at the same time
+            as an earlier version.
+            </p>
+        </description>
+    </info>
+
+    <publications>
+        <artifact/>
+        <artifact name="source" type="source" ext="zip"/>
+        <artifact name="javadoc" type="javadoc" ext="zip"/>
+    </publications>
+
+</ivy-module>

--- a/src/modules/org.apache.commons/commons-lang3/3.9/packager.xml
+++ b/src/modules/org.apache.commons/commons-lang3/3.9/packager.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2014 Zac Jacobson.
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<packager-module>
+    <m2resource>
+        <artifact tofile="artifacts/jars/${ivy.packager.module}.jar" sha1="0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/javadoc.zip" sha1="9872098000a4d91f9bbd1ad42859553ccaed0e0c"/>
+        <artifact classifier="sources" tofile="artifacts/sources/source.zip" sha1="8f1cb192e229bc4cd1c900c51171d96706e6d195"/>
+    </m2resource>
+</packager-module>

--- a/src/modules/org.apache.commons/commons-text/1.6/ivy.xml
+++ b/src/modules/org.apache.commons/commons-text/1.6/ivy.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2019 Bill Soul
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<ivy-module>
+
+    <info publication="20181013000000">
+        <license name="Apache License, Version 2.0" url="http://www.apache.org/licenses/LICENSE-2.0"/>
+        <description homepage="http://commons.apache.org/proper/commons-text/">
+            <p>
+            Apache Commons Text is a library focused on algorithms working on strings.
+            </p>
+        </description>
+    </info>
+
+    <publications>
+        <artifact/>
+        <artifact name="source" type="source" ext="zip"/>
+        <artifact name="javadoc" type="javadoc" ext="zip"/>
+    </publications>
+
+    <dependencies>
+        <dependency org="org.apache.commons" name="commons-lang3" rev="[3.8.1,)" conf="default->default"/>
+    </dependencies>
+</ivy-module>

--- a/src/modules/org.apache.commons/commons-text/1.6/packager.xml
+++ b/src/modules/org.apache.commons/commons-text/1.6/packager.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2019 Bill Soul
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<packager-module>
+    <m2resource>
+        <artifact tofile="artifacts/jars/${ivy.packager.module}.jar" sha1="ba72cf0c40cf701e972fe7720ae844629f4ecca2"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/javadoc.zip" sha1="72ecac738bee41dc39d7e987e93446a98f2d067e"/>
+        <artifact classifier="sources" tofile="artifacts/sources/source.zip" sha1="537f45636348da7c83861c537ec5ebb36933f5f4"/>
+    </m2resource>
+</packager-module>


### PR DESCRIPTION
Added Apache commons-lang3 version 3.9 based on prior versions.
Added new Apache commons-text library.