### PR TITLE
Upgraded kafka-clients to version 3.3.1 based on prior version.

### DIFF
--- a/src/modules/ch.qos/reload4j/1.2.19/ivy.xml
+++ b/src/modules/ch.qos/reload4j/1.2.19/ivy.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2012 Mark Thomas
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<ivy-module>
+
+    <info publication="20220721000000">
+        <license name="Apache License, Version 2.0" url="http://www.apache.org/licenses/LICENSE-2.0"/>
+        <description homepage="https://reload4j.qos.ch">
+            Reload4j revives EOLed log4j 1.x
+        </description>
+    </info>
+
+    <configurations>
+        <conf name="default" description="Default configuration"/>
+        <conf name="jmx" extends="default" description="JMX support"/>
+        <conf name="jms" extends="default" description="JMS support"/>
+        <conf name="mail" extends="default" description="JavaMail support"/>
+    </configurations>
+
+    <publications>
+        <artifact/>
+        <artifact name="source" type="source" ext="zip"/>
+        <artifact name="javadoc" type="javadoc" ext="zip"/>
+    </publications>
+
+    <dependencies>
+        <dependency org="javax.mail" name="javamail" rev="[1.4.7,2.0[" conf="mail->default"/>
+        <dependency org="javax.jms" name="jms" rev="[1.1,2.0[" conf="jms->default"/>
+        <dependency org="javax.management" name="jmx" rev="[1.2.1,2.0[" conf="jmx->default,tools"/>
+    </dependencies>
+
+</ivy-module>

--- a/src/modules/ch.qos/reload4j/1.2.19/packager.xml
+++ b/src/modules/ch.qos/reload4j/1.2.19/packager.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2012 Mark Thomas
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<packager-module>
+    <m2resource groupId="${ivy.packager.organisation}.${ivy.packager.module}">
+        <artifact tofile="artifacts/jars/${ivy.packager.module}.jar" sha1="4eae9978468c5e885a6fb44df7e2bbc07a20e6ce"/>
+        <artifact classifier="sources" tofile="artifacts/sources/source.zip" sha1="435055e6fec4dfaebf3f356c18246480e2157548"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/javadoc.zip" sha1="8b89cf51d3b21028d3297079431bdc5a4909642e"/>
+    </m2resource>
+</packager-module>

--- a/src/modules/com.github.luben/zstd-jni/1.5.2-1/ivy.xml
+++ b/src/modules/com.github.luben/zstd-jni/1.5.2-1/ivy.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2022 Bill Soul
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<ivy-module>
+
+    <info publication="20220122113700">
+        <license name="BSD 2-Clause License" url="https://opensource.org/licenses/BSD-2-Clause"/>
+        <description homepage="https://github.com/luben/zstd-jni">
+             JNI bindings for Zstd native library that provides fast and high compression lossless algorithm for Android, Java and all JVM languages.
+        </description>
+    </info>
+
+    <configurations>
+        <conf name="default" description="Default with all architectures included"/>
+        <conf name="darwin-aarch64" description="Single architecture library for darwin-aarch64"/>
+        <conf name="darwin-x86_64" description="Single architecture library for darwin-x86_64 (MacOS X)"/>
+        <conf name="freebsd-amd64" description="Single architecture library for freebsd-amd64"/>
+        <conf name="freebsd-i386" description="Single architecture library for freebsd-i386"/>
+        <conf name="linux-aarch64" description="Single architecture library for linux-aarch64"/>
+        <conf name="linux-amd64" description="Single architecture library for linux-amd64"/>
+        <conf name="linux-arm" description="Single architecture library for linux-armhf"/> <!-- Author describes it as "armhf", but file names, paths, etc. are "arm" -->
+        <conf name="linux-i386" description="Single architecture library for linux-i386"/>
+        <conf name="linux-mips64" description="Single architecture library for linux-mips64"/>
+        <conf name="linux-ppc64" description="Single architecture library for linux-ppc64"/>
+        <conf name="linux-ppc64le" description="Single architecture library for linux-ppc64le"/>
+        <conf name="linux-s390x" description="Single architecture library for linux-s390x"/>
+        <conf name="win-amd64" description="Single architecture library for win-amd64"/>
+        <conf name="win-x86" description="Single architecture library for win-x86"/>
+    </configurations>
+
+    <publications>
+        <artifact conf="default"/>
+        <artifact name="source" type="source" ext="zip" conf="default"/>
+        <artifact name="javadoc" type="javadoc" ext="zip" conf="default"/>
+
+        <artifact name="zstd-jni-darwin_aarch64" conf="darwin-aarch64"/>
+        <artifact name="zstd-jni-darwin_x86_64" conf="darwin-x86_64"/>
+        <artifact name="zstd-jni-freebsd_amd64" conf="freebsd-amd64"/>
+        <artifact name="zstd-jni-freebsd_i386" conf="freebsd-i386"/>
+        <artifact name="zstd-jni-linux_aarch64" conf="linux-aarch64"/>
+        <artifact name="zstd-jni-linux_amd64" conf="linux-amd64"/>
+        <artifact name="zstd-jni-linux_arm" conf="linux-arm"/>
+        <artifact name="zstd-jni-linux_i386" conf="linux-i386"/>
+        <artifact name="zstd-jni-linux_mips64" conf="linux-mips64"/>
+        <artifact name="zstd-jni-linux_ppc64" conf="linux-ppc64"/>
+        <artifact name="zstd-jni-linux_ppc64le" conf="linux-ppc64le"/>
+        <artifact name="zstd-jni-linux_s390x" conf="linux-s390x"/>
+        <artifact name="zstd-jni-win_amd64" conf="win-amd64"/>
+        <artifact name="zstd-jni-win_x86" conf="win-x86"/>
+    </publications>
+
+</ivy-module>

--- a/src/modules/com.github.luben/zstd-jni/1.5.2-1/packager.xml
+++ b/src/modules/com.github.luben/zstd-jni/1.5.2-1/packager.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2022 Bill Soul
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<packager-module>
+    <m2resource>
+        <artifact tofile="artifacts/jars/${ivy.packager.module}.jar" sha1="fad786abc1d1b81570e8d9a2fc8a1ef479bc27b6"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/javadoc.zip" sha1="1c8371c485e196e3e167e0344382ba709139105e"/>
+        <artifact classifier="sources" tofile="artifacts/sources/source.zip" sha1="fc4dca644fbb8527bc77622209b933a19572a983"/>
+
+        <artifact classifier="darwin_aarch64" tofile="artifacts/jars/${ivy.packager.module}-darwin_aarch64.jar" sha1="265e586b8e41bab07a5257ddf51ff6e2f4b925a9"/>
+        <artifact classifier="darwin_x86_64" tofile="artifacts/jars/${ivy.packager.module}-darwin_x86_64.jar" sha1="d97d2917429504cad2d23ad67de475bbeaebe94b"/>
+        <artifact classifier="freebsd_amd64" tofile="artifacts/jars/${ivy.packager.module}-freebsd_amd64.jar" sha1="04688678d803639e1c1e27013da5880b949fe6ca"/>
+        <artifact classifier="freebsd_i386" tofile="artifacts/jars/${ivy.packager.module}-freebsd_i386.jar" sha1="2077cd06752d5591b2081c74e8868217b6c6d155"/>
+        <artifact classifier="linux_aarch64" tofile="artifacts/jars/${ivy.packager.module}-linux_aarch64.jar" sha1="12995a42f28686011a38b95ed90aa495b12b3993"/>
+        <artifact classifier="linux_amd64" tofile="artifacts/jars/${ivy.packager.module}-linux_amd64.jar" sha1="7de36098f1ae4d59429911ae72d89120ceb73c54"/>
+        <artifact classifier="linux_arm" tofile="artifacts/jars/${ivy.packager.module}-linux_arm.jar" sha1="b3d8f3c79c32c1562a2aaccda82612b06e680bf1"/>
+        <artifact classifier="linux_i386" tofile="artifacts/jars/${ivy.packager.module}-linux_i386.jar" sha1="8dc9e036577c08e46d4e611e6bdce1818a9b634c"/>
+        <artifact classifier="linux_mips64" tofile="artifacts/jars/${ivy.packager.module}-linux_mips64.jar" sha1="1c941efae18f5b202d6abde10704eb2b78f3a90d"/>
+        <artifact classifier="linux_ppc64" tofile="artifacts/jars/${ivy.packager.module}-linux_ppc64.jar" sha1="d7edc9d1867c17a6ea710c8c6958e91f013e8d55"/>
+        <artifact classifier="linux_ppc64le" tofile="artifacts/jars/${ivy.packager.module}-linux_ppc64le.jar" sha1="8e0ac8cd6f0e32fb094b28dae3035e82013734cb"/>
+        <artifact classifier="linux_s390x" tofile="artifacts/jars/${ivy.packager.module}-linux_s390x.jar" sha1="c2339fe1834414c9ec9ae479376fd097a58b2c23"/>
+        <artifact classifier="win_amd64" tofile="artifacts/jars/${ivy.packager.module}-win_amd64.jar" sha1="292f3bb8ea38f252d9bdf4b2ae6d24cc8c142d4c"/>
+        <artifact classifier="win_x86" tofile="artifacts/jars/${ivy.packager.module}-win_x86.jar" sha1="cb86a31987e47be29e6d066e62fe63e1beef7f66"/>
+    </m2resource>
+</packager-module>

--- a/src/modules/org.apache.kafka/kafka-clients/3.3.1/ivy.xml
+++ b/src/modules/org.apache.kafka/kafka-clients/3.3.1/ivy.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2022 Bill Soul
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<ivy-module>
+
+    <info publication="20220929192500">
+        <license name="Apache License, Version 2.0" url="http://www.apache.org/licenses/LICENSE-2.0"/>
+        <description homepage="https://kafka.apache.org/">
+            Apache Kafka is an open-source distributed event streaming platform used by thousands of companies for high-performance data pipelines, streaming analytics, data integration, and mission-critical applications.
+        </description>
+    </info>
+
+    <publications>
+        <artifact/>
+        <artifact name="source" type="source" ext="zip"/>
+        <artifact name="javadoc" type="javadoc" ext="zip"/>
+    </publications>
+
+    <dependencies>
+        <dependency org="com.github.luben" name="zstd-jni" rev="[1.5.2-1,)" conf="default->default"/>
+        <dependency org="org.lz4" name="lz4-java" rev="[1.8.0,)" conf="default->default"/>
+        <dependency org="org.xerial.snappy" name="snappy-java" rev="[1.1.8.4,)" conf="default->default"/>
+        <dependency org="org.slf4j" name="slf4j" rev="[1.7.36,)" conf="default->core"/>
+    </dependencies>
+</ivy-module>

--- a/src/modules/org.apache.kafka/kafka-clients/3.3.1/packager.xml
+++ b/src/modules/org.apache.kafka/kafka-clients/3.3.1/packager.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2018 Bill Soul
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<packager-module>
+    <m2resource>
+        <artifact tofile="artifacts/jars/${ivy.packager.module}.jar" sha1="aea4008ab34761ef8057b13cce6d0ec767397406"/>
+        <artifact classifier="sources" tofile="artifacts/sources/source.zip" sha1="5d00fda22b83c4f1abacff0e8db780f86f9e723d"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/javadoc.zip" sha1="9380d3fe817e0d7ef680dc80f670605fe21aad13"/>
+    </m2resource>
+</packager-module>

--- a/src/modules/org.lz4/lz4-java/1.8.0/ivy.xml
+++ b/src/modules/org.lz4/lz4-java/1.8.0/ivy.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2022 Bill Soul
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<ivy-module>
+
+    <info publication="20210619063100">
+        <license name="Apache License, Version 2.0" url="http://www.apache.org/licenses/LICENSE-2.0"/>
+        <description homepage="https://github.com/lz4/lz4-java">
+            <p>
+            LZ4 compression for Java, based on Yann Collet's work available at
+            http://code.google.com/p/lz4/
+            </p>
+
+            <p>
+            This library provides access to two compression methods that both
+            generate a valid LZ4 stream:
+            <ul>
+            <li>fast scan (LZ4):</li>
+                <ul>
+                <li>low memory footprint (~ 16 KB),</li>
+                <li>very fast (fast scan with skipping heuristics in case the
+                input looks incompressible),</li>
+                <li>reasonable compression ratio (depending on the redundancy
+                of the input).</li>
+                </ul>
+
+            <li>high compression (LZ4 HC):</li>
+                <ul>
+                <li> medium memory footprint (~ 256 KB),</li>
+                <li>rather slow (~ 10 times slower than LZ4),</li>
+                <li>good compression ratio (depending on the size and the redundancy
+                of the input).</li>
+                </ul>
+            </ul>
+            </p>
+            
+            <p>
+            The streams produced by those 2 compression algorithms use the same
+            compression format, are very fast to decompress and can be decompressed
+            by the same decompressor instance.
+            </p>
+        </description>
+    </info>
+
+    <publications>
+        <artifact/>
+        <artifact name="source" type="source" ext="zip"/>
+        <artifact name="javadoc" type="javadoc" ext="zip"/>
+    </publications>
+</ivy-module>

--- a/src/modules/org.lz4/lz4-java/1.8.0/packager.xml
+++ b/src/modules/org.lz4/lz4-java/1.8.0/packager.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2022 Bill Soul
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<packager-module>
+    <m2resource>
+        <artifact tofile="artifacts/jars/${ivy.packager.module}.jar" sha1="4b986a99445e49ea5fbf5d149c4b63f6ed6c6780"/>
+        <artifact classifier="sources" tofile="artifacts/sources/source.zip" sha1="7609c362f37f0c0bd3743bc1976df2daa28ad19e"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/javadoc.zip" sha1="87605e3026e1205ccfafd20f0711e718849cedba"/>
+    </m2resource>
+</packager-module>

--- a/src/modules/org.slf4j/slf4j/1.7.36/ivy.xml
+++ b/src/modules/org.slf4j/slf4j/1.7.36/ivy.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2014 Zac Jacobson
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<ivy-module>
+
+  <info publication="20191216000000">
+    <license name="SLF4J License" url="http://www.slf4j.org/license.html"/>
+    <description homepage="http://www.slf4j.org/">
+
+      <p>
+        The Simple Logging Facade for Java or (SLF4J) serves as a simple
+        facade or abstraction for various logging frameworks, e.g.
+        java.util.logging, log4j and logback, allowing the end user to
+        plug in the desired logging framework at <em>deployment</em> time.
+      </p>
+
+    </description>
+  </info>
+
+  <configurations>
+    <conf name="core" description="SLF4J core conf"/>
+    <conf name="default" extends="core" description="SLF4J default conf (Log4J enabled)"/>
+    <conf name="simple" extends="core" description="Simple Logger support"/>
+    <conf name="nop" extends="core" description="NOP (no operation) Logger support"/>
+    <conf name="jul" extends="core" description="java.util.logging support"/>
+    <conf name="reload4j" extends="default" description="Reload4j 1.2.x support"/>
+    <conf name="jcl" extends="core" description="Jakarta Commons Logging support"/>
+    <conf name="android" extends="core" description="SLF4J Android Binding"/>
+    <conf name="ext" extends="core" description="Enable profiling support"/>
+    <conf name="jcl-migration" extends="core" description="Gradual migration from Jakarta Commons Logging"/>
+    <conf name="log4j-migration" extends="core" description="Gradual migration from Log4J"/>
+    <conf name="jul-migration" extends="core" description="Gradual migration from java.util.logging"/>
+    <conf name="osgi-migration" extends="core" description="Gradual migration from OSGi LogService"/>
+    <conf name="migrator" description="Tool to migrate code to SLF4J"/>
+  </configurations>
+
+  <publications>
+    <artifact name="slf4j-api" conf="core"/>
+    <artifact name="slf4j-simple" conf="simple"/>
+    <artifact name="slf4j-nop" conf="nop"/>
+    <artifact name="slf4j-jdk14" conf="jul"/>
+    <artifact name="slf4j-reload4j" conf="default, reload4j"/> <!-- Formerly slf4j-log4j12 -->
+    <artifact name="slf4j-jcl" conf="jcl"/>
+    <artifact name="slf4j-android" conf="android"/>
+    <artifact name="slf4j-ext" conf="ext"/>
+    <artifact name="jcl-over-slf4j" conf="jcl-migration"/>
+    <artifact name="log4j-over-slf4j" conf="log4j-migration"/>
+    <artifact name="jul-to-slf4j" conf="jul-migration"/>
+    <artifact name="osgi-over-slf4j" conf="osgi-migration"/>
+    <artifact name="slf4j-migrator" conf="migrator"/>
+
+    <artifact name="slf4j-api" type="source" ext="zip" conf="core"/>
+    <artifact name="slf4j-simple" type="source" ext="zip" conf="simple"/>
+    <artifact name="slf4j-nop" type="source" ext="zip" conf="nop"/>
+    <artifact name="slf4j-jdk14" type="source" ext="zip" conf="jul"/>
+    <artifact name="slf4j-reload4j" type="source" ext="zip" conf="default, reload4j"/>
+    <artifact name="slf4j-jcl" type="source" ext="zip" conf="jcl"/>
+    <artifact name="slf4j-android" type="source" ext="zip" conf="android"/>
+    <artifact name="slf4j-ext" type="source" ext="zip" conf="ext"/>
+    <artifact name="jcl-over-slf4j" type="source" ext="zip" conf="jcl-migration"/>
+    <artifact name="log4j-over-slf4j" type="source" ext="zip" conf="log4j-migration"/>
+    <artifact name="jul-to-slf4j" type="source" ext="zip" conf="jul-migration"/>
+    <artifact name="osgi-over-slf4j" type="source" ext="zip" conf="osgi-migration"/>
+    <artifact name="slf4j-migrator" type="source" ext="zip" conf="migrator"/>
+
+    <artifact name="slf4j-api" type="javadoc" ext="zip" conf="core"/>
+    <artifact name="slf4j-simple" type="javadoc" ext="zip" conf="simple"/>
+    <artifact name="slf4j-nop" type="javadoc" ext="zip" conf="nop"/>
+    <artifact name="slf4j-jdk14" type="javadoc" ext="zip" conf="jul"/>
+    <artifact name="slf4j-reload4j" type="javadoc" ext="zip" conf="default, reload4j"/>
+    <artifact name="slf4j-jcl" type="javadoc" ext="zip" conf="jcl"/>
+    <artifact name="slf4j-android" type="javadoc" ext="zip" conf="android"/>
+    <artifact name="slf4j-ext" type="javadoc" ext="zip" conf="ext"/>
+    <artifact name="jcl-over-slf4j" type="javadoc" ext="zip" conf="jcl-migration"/>
+    <artifact name="log4j-over-slf4j" type="javadoc" ext="zip" conf="log4j-migration"/>
+    <artifact name="jul-to-slf4j" type="javadoc" ext="zip" conf="jul-migration"/>
+    <artifact name="osgi-over-slf4j" type="javadoc" ext="zip" conf="osgi-migration"/>
+    <artifact name="slf4j-migrator" type="javadoc" ext="zip" conf="migrator"/>
+  </publications>
+
+  <dependencies>
+    <dependency org="ch.qos.reload4j" name="reload4j" rev="[1.2.19,1.3[" conf="reload4j->default"/>
+    <dependency org="org.apache.commons" name="commons-logging" rev="[1.1.1,1.2[" conf="jcl->default"/>
+    <dependency org="org.jboss" name="javassist" rev="[3.4,4.0[" conf="ext->default"/>
+  </dependencies>
+
+</ivy-module>

--- a/src/modules/org.slf4j/slf4j/1.7.36/packager.xml
+++ b/src/modules/org.slf4j/slf4j/1.7.36/packager.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2013 Mark Thomas
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<packager-module>
+    <m2resource artifactId="slf4j-api">
+        <artifact tofile="artifacts/jars/slf4j-api.jar" sha1="6c62681a2f655b49963a5983b8b0950a6120ae14"/>
+        <artifact classifier="sources" tofile="artifacts/sources/slf4j-api.zip" sha1="ae9c1aae0033af915cfa75d850eb9d880f21a701"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/slf4j-api.zip" sha1="f91b284d55365e88248e6493bc5959c8e81d5fa3"/>
+    </m2resource>
+    <m2resource artifactId="slf4j-simple">
+        <artifact tofile="artifacts/jars/slf4j-simple.jar" sha1="a41f9cfe6faafb2eb83a1c7dd2d0dfd844e2a936"/>
+        <artifact classifier="sources" tofile="artifacts/sources/slf4j-simple.zip" sha1="e13ec88aa7dc78814f64ffe2b210ce621cd66dc3"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/slf4j-simple.zip" sha1="b3120ecc3eb7cb834112e5953085291b89abfabf"/>
+    </m2resource>
+    <m2resource artifactId="slf4j-nop">
+        <artifact tofile="artifacts/jars/slf4j-nop.jar" sha1="a3c1eb685d59414527faa93623acae311c184032"/>
+        <artifact classifier="sources" tofile="artifacts/sources/slf4j-nop.zip" sha1="ed83b905b1c5d427a67bd03cff825207899711c3"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/slf4j-nop.zip" sha1="3e236c211f5c09d428e8846fb3e18ce7de6443d3"/>
+    </m2resource>
+    <m2resource artifactId="slf4j-jdk14">
+        <artifact tofile="artifacts/jars/slf4j-jdk14.jar" sha1="4a18af6554bfe48b0f76eec98119c417da23c7e1"/>
+        <artifact classifier="sources" tofile="artifacts/sources/slf4j-jdk14.zip" sha1="8b0a1af45145bb24d5bc0fad80fe6c629468bf22"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/slf4j-jdk14.zip" sha1="d989b2ab1dd172c11e1fccbbb984ba6838a679d7"/>
+    </m2resource>
+    <m2resource artifactId="slf4j-reload4j">
+        <artifact tofile="artifacts/jars/slf4j-reload4j.jar" sha1="db708f7d959dee1857ac524636e85ecf2e1781c1"/>
+        <artifact classifier="sources" tofile="artifacts/sources/slf4j-reload4j.zip" sha1="7adde2baa6395d097ab737516ad7c7fccf7044ba"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/slf4j-reload4j.zip" sha1="ece0aa8137127f6755558c214f7704e088bee585"/>
+    </m2resource>
+    <m2resource artifactId="slf4j-jcl">
+        <artifact tofile="artifacts/jars/slf4j-jcl.jar" sha1="654cff00e29778e28e0069e139a65927306eec2b"/>
+        <artifact classifier="sources" tofile="artifacts/sources/slf4j-jcl.zip" sha1="319292554b0be94d7c0d63436f07ce438b7e2819"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/slf4j-jcl.zip" sha1="fb7d9b8fe7b3c0fadd4d2daaf3b52b1a30ee0701"/>
+    </m2resource>
+    <m2resource artifactId="slf4j-android">
+        <artifact tofile="artifacts/jars/slf4j-android.jar" sha1="0136797e409128939b88a89b8a8880550b7c12e8"/>
+        <artifact classifier="sources" tofile="artifacts/sources/slf4j-android.zip" sha1="b86a9e4c459283c8ce924bc46b0b26c1b5169f3c"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/slf4j-android.zip" sha1="c606b72c907b96f474cbe11855d2d3057e5e5264"/>
+    </m2resource>
+    <m2resource artifactId="slf4j-ext">
+        <artifact tofile="artifacts/jars/slf4j-ext.jar" sha1="99f282aea4b6dbca04d00f0ade6e5ed61ee7091a"/>
+        <artifact classifier="sources" tofile="artifacts/sources/slf4j-ext.zip" sha1="648212c0b30e888eca10c0c1d146dc99b894cce8"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/slf4j-ext.zip" sha1="5f94b184e2e4bc357f1e9d2c342e9cc4fe17b112"/>
+    </m2resource>
+    <m2resource artifactId="jcl-over-slf4j">
+        <artifact tofile="artifacts/jars/jcl-over-slf4j.jar" sha1="d877e195a05aca4a2f1ad2ff14bfec1393af4b5e"/>
+        <artifact classifier="sources" tofile="artifacts/sources/jcl-over-slf4j.zip" sha1="91b21b162173dfc6bb676bc7f4865cdd268eac68"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/jcl-over-slf4j.zip" sha1="cd5445a12ecf2a6709b0e4ecb0cd9cd202f59844"/>
+    </m2resource>
+    <m2resource artifactId="log4j-over-slf4j">
+        <artifact tofile="artifacts/jars/log4j-over-slf4j.jar" sha1="2a753acda077203a4794f106871bb237501c9a53"/>
+        <artifact classifier="sources" tofile="artifacts/sources/log4j-over-slf4j.zip" sha1="a715f0f390b52daade0ce2f1002b9efb50f5a0ca"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/log4j-over-slf4j.zip" sha1="7c3aa41932b82228c6b786cd51ed58142637fd59"/>
+    </m2resource>
+    <m2resource artifactId="jul-to-slf4j">
+        <artifact tofile="artifacts/jars/jul-to-slf4j.jar" sha1="ed46d81cef9c412a88caef405b58f93a678ff2ca"/>
+        <artifact classifier="sources" tofile="artifacts/sources/jul-to-slf4j.zip" sha1="86e5d1e467b4b30ece98254248e7e726e747ec58"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/jul-to-slf4j.zip" sha1="52f2611082eb145631e16c5f2ec46600a7e155bb"/>
+    </m2resource>
+    <m2resource artifactId="osgi-over-slf4j">
+        <artifact tofile="artifacts/jars/osgi-over-slf4j.jar" sha1="df50a746d93877b9fa1af9d9869c4dbc8a22074a"/>
+        <artifact classifier="sources" tofile="artifacts/sources/osgi-over-slf4j.zip" sha1="45c84e93cec408292ac148e87676a15ac5752818"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/osgi-over-slf4j.zip" sha1="e945d4473a9301cb2419141b9f9771fe6ae408f5"/>
+    </m2resource>
+    <m2resource artifactId="slf4j-migrator">
+        <artifact tofile="artifacts/jars/slf4j-migrator.jar" sha1="15411d0b57b04e0a9718fee2c34a1b24b5e35643"/>
+        <artifact classifier="sources" tofile="artifacts/sources/slf4j-migrator.zip" sha1="ea1910eab3ecca843b55b9de33b5e95103b1c3b9"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/slf4j-migrator.zip" sha1="8ffd4e06ca50e1ee0b02101e17c18c1f049823ae"/>
+    </m2resource>
+</packager-module>

--- a/src/modules/org.xerial.snappy/snappy-java/1.1.8.4/ivy.xml
+++ b/src/modules/org.xerial.snappy/snappy-java/1.1.8.4/ivy.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2014 Mark THomas
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<ivy-module>
+
+    <info publication="20210125000000">
+        <license name="Apache License, Version 2.0" url="http://www.apache.org/licenses/LICENSE-2.0"/>
+        <description homepage="https://github.com/xerial/snappy-java">
+            <p>
+                snappy-java: A fast compression/decompression library
+            </p>
+        </description>
+    </info>
+
+    <publications>
+        <artifact />
+        <artifact type="source" ext="zip"/>
+        <artifact type="javadoc" ext="zip"/>
+    </publications>
+
+</ivy-module>

--- a/src/modules/org.xerial.snappy/snappy-java/1.1.8.4/packager.xml
+++ b/src/modules/org.xerial.snappy/snappy-java/1.1.8.4/packager.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2014 Mark Thomas
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<packager-module>
+    <m2resource>
+        <artifact tofile="artifacts/jars/${ivy.packager.module}.jar" sha1="66f0d56454509f6e36175f2331572e250e04a6cc"/>
+        <artifact classifier="sources" tofile="artifacts/sources/${ivy.packager.module}.zip" sha1="ae02b50fff26612bdf687952dc970ce9760b620c"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/${ivy.packager.module}.zip" sha1="dce118f3ff6388ac7f0c49a6c7caff9d1be92d66"/>
+    </m2resource>
+</packager-module>


### PR DESCRIPTION
Upgraded kafka-clients downstream dependencies:
* reload4j 1.2.19 based on log4j 1.x
* lz4-java 1.8.0 based on prior version
* slf4j 1.7.36 based on prior version
* snappy-java 1.1.8.4 based on prior version
* zstd-jni 1.5.2-1 based on prior version