### PR TITLE
Added combined JAXB 2.3.9 based on prior version.

### DIFF
--- a/src/modules/jakarta.xml.bind/jaxb/2.3.3/ivy.xml
+++ b/src/modules/jakarta.xml.bind/jaxb/2.3.3/ivy.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2012 Stephen Lynn
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<ivy-module>
+
+    <info publication="20200127093500">
+        <license name="Eclipse Distribution License - v 1.0"
+          url="http://www.eclipse.org/org/documents/edl-v10.php"/>
+        <description homepage="https://github.com/eclipse-ee4j/jaxb-api">
+
+            <p>
+            The Jakarta XML Binding provides an API and tools that automate the mapping between XML documents and Java objects.
+            </p>
+        </description>
+    </info>
+
+    <publications>
+        <artifact name="jakarta.xml.bind-api" />
+        <artifact name="jakarta.xml.bind-api" type="source" ext="jar"/>
+        <artifact name="jakarta.xml.bind-api" type="javadoc" ext="jar"/>
+    </publications>
+
+    <dependencies>
+        <dependency org="jakarta.activation" name="jaf" rev="[1.2.1,2.0[" conf="default->default"/>
+    </dependencies>
+
+</ivy-module>

--- a/src/modules/jakarta.xml.bind/jaxb/2.3.3/packager.xml
+++ b/src/modules/jakarta.xml.bind/jaxb/2.3.3/packager.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2012 Stephen Lynn
+    Copyright 2012 Martin Weber
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<packager-module>
+    <property name="name" value="${ivy.packager.organisation}"/>
+
+    <m2resource artifactId="${name}-api">
+        <artifact tofile="artifacts/jars/${name}-api.jar" sha1="48e3b9cfc10752fba3521d6511f4165bea951801"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/${name}-api.jar" sha1="5685a1e75f9135dcc71e73a690b378e90fcd3b53"/>
+        <artifact classifier="sources" tofile="artifacts/sources/${name}-api.jar" sha1="d83744bae211a4072c39f007000a13f501a88395"/>
+    </m2resource>
+</packager-module>

--- a/src/modules/javax.xml.bind/jaxb/2.3.9/ivy.xml
+++ b/src/modules/javax.xml.bind/jaxb/2.3.9/ivy.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2012 Stephen Lynn
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<ivy-module>
+
+    <info publication="20231017193800">
+        <license name="Dual license consisting of the  CDDL v1.0 and GPL v2"
+          url="https://glassfish.java.net/public/CDDL+GPL.html"/>
+        <description homepage="https://github.com/eclipse-ee4j/jaxb-ri/">
+
+            <p>
+            Welcome to the JAXB Reference Implementation Project. This
+            project is part of <a href="https://java.net/projects/metro/">Project Metro</a>
+            and is in the <a href="http://glassfish.dev.java.net/">Glassfish community</a>
+            at java.net.
+            </p>
+
+            <p>
+            This project develops and evolves the code base for the
+            reference implementation of the JAXB specification. The
+            current code base supports JAXB 1.0, 2.0, and 2.1 but the
+            project will track future versions of the JAXB specifications.
+            </p>
+
+            <p>
+            Standards Supported:
+            <ul>
+                <li>JAXB 2.0/2.1</li>
+                <li>W3C XML Schema</li>
+                <li>XML DTD</li>
+            </ul>
+            </p>
+        </description>
+    </info>
+
+    <configurations>
+        <conf name="runtime" description="Normal runtime configuration"/>
+        <conf name="compile" description="Normal compile configuration"/>
+        <conf name="default" extends="runtime,compile" description="Runtime + compile configurations"/>
+    </configurations>
+
+    <publications>
+        <artifact name="jaxb-impl" conf="runtime"/>
+        <artifact name="jaxb-xjc" conf="compile"/>
+
+        <artifact name="jaxb-impl" type="source" ext="jar" conf="runtime"/>
+        <artifact name="jaxb-xjc" type="source" ext="jar" conf="compile"/>
+
+        <artifact name="jaxb-impl" type="javadoc" ext="jar" conf="runtime" />
+        <artifact name="jaxb-xjc" type="javadoc" ext="jar" conf="compile" />
+    </publications>
+
+    <dependencies>
+        <dependency org="jakarta.xml.bind" name="jaxb" rev="2.3.3" conf="compile->default"/>
+        <dependency org="javax.activation" name="jaf" rev="[1.1,2.0[" conf="default->default"/>
+        <dependency org="javax.xml.stream" name="jsr173_api" rev="1.0" conf="runtime->default"/>
+    </dependencies>
+
+</ivy-module>

--- a/src/modules/javax.xml.bind/jaxb/2.3.9/packager.xml
+++ b/src/modules/javax.xml.bind/jaxb/2.3.9/packager.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2012 Stephen Lynn
+    Copyright 2012 Martin Weber
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may
+    not use this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+-->
+
+<packager-module>
+    <property name="name" value="${ivy.packager.module}"/>
+
+    <m2resource groupId="com.sun.xml.bind" artifactId="${name}-impl">
+        <artifact tofile="artifacts/jars/jaxb-impl.jar" sha1="95076261a51690f95b29e09fd6ff9f8a90381af0"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/${name}-impl.jar" sha1="6beae207b75e124597383746418615ce6d2a3226"/>
+        <artifact classifier="sources" tofile="artifacts/sources/${name}-impl.jar" sha1="c0344c4326e002e2e77ca51dcab2d0cf436b711f"/>
+    </m2resource>
+
+    <m2resource groupId="com.sun.xml.bind" artifactId="${name}-xjc">
+        <artifact tofile="artifacts/jars/${name}-xjc.jar" sha1="4a45d6b44909dba42c936977cd411e52c5431f1b"/>
+        <artifact classifier="javadoc" tofile="artifacts/javadocs/${name}-xjc.jar" sha1="7a9a32418df73b0e92e66a3437ba301d201ae80d"/>
+        <artifact classifier="sources" tofile="artifacts/sources/${name}-xjc.jar" sha1="2954c8f9a84e0e93ffeb1c856ee4456d64fbb412"/>
+    </m2resource>
+</packager-module>


### PR DESCRIPTION
Broke out JAXB-API as a dependency since 2.3.3 is the final 2.3.X release.
Added JAXB-API 2.3.3 based on prior version.